### PR TITLE
Fix code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/Website/js/bootstrap.js
+++ b/Website/js/bootstrap.js
@@ -148,7 +148,11 @@
       }
 
       try {
-        return document.querySelector(selector) ? selector : null;
+        // Validate the selector to ensure it does not contain potentially harmful characters
+        if (document.querySelector(selector) && /^[a-zA-Z0-9_\-#\.]+$/.test(selector)) {
+          return selector;
+        }
+        return null;
       } catch (err) {
         return null;
       }
@@ -1080,7 +1084,7 @@
           return;
         }
 
-        var target = $(selector)[0];
+        var target = $.find(selector)[0];
 
         if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
           return;


### PR DESCRIPTION
Fixes [https://github.com/DefinetlyNotAI/WesHacks/security/code-scanning/10](https://github.com/DefinetlyNotAI/WesHacks/security/code-scanning/10)

To fix the problem, we need to ensure that the `selector` derived from the `data-target` attribute is properly sanitized before being used. One way to achieve this is by using a more restrictive method to select elements, such as `$.find`, which interprets the input strictly as a CSS selector and not as HTML. Additionally, we should validate the `selector` to ensure it does not contain any potentially harmful characters.

1. Replace the use of `$(selector)` with `$.find(selector)` to prevent interpreting the selector as HTML.
2. Add validation to ensure the `selector` is a valid CSS selector and does not contain any potentially harmful characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
